### PR TITLE
論文編集機能の作成

### DIFF
--- a/app/Http/Controllers/RonbunController.php
+++ b/app/Http/Controllers/RonbunController.php
@@ -46,6 +46,16 @@ class RonbunController extends Controller
         return redirect('/mypage')->with('flash_message', __('Registered!'));
     }
 
+    public function edit($id)
+    {
+        if (!ctype_digit($id)) {
+            return redirect('/mypage')->with('flash_message', __('Invalid operation was performed.'));
+        }
+
+        $ronbun = Ronbun::find($id);
+        return view('ronbun.edit', compact('ronbun'));
+    }
+
     public function destroy($id)
     {
         if (!ctype_digit($id)) {

--- a/app/Http/Controllers/RonbunController.php
+++ b/app/Http/Controllers/RonbunController.php
@@ -51,9 +51,37 @@ class RonbunController extends Controller
         if (!ctype_digit($id)) {
             return redirect('/mypage')->with('flash_message', __('Invalid operation was performed.'));
         }
+        $categories = Category::select('id', 'name')->get()->all();
+        $category_names = [];
+        foreach ($categories as $category) {
+            $category_names[$category->id] = $category->name;
+        }
 
         $ronbun = Ronbun::find($id);
-        return view('ronbun.edit', compact('ronbun'));
+        return view('ronbun.edit', compact('ronbun', 'category_names'));
+    }
+
+    public function update(Request $request, $id)
+    {
+        if (!ctype_digit($id)) {
+            return redirect('/mypage')->with('flash_message', __('Invalid operation was performed.'));
+        }
+
+        $ronbun = new Ronbun();
+        $ronbun->fill($request->all());
+        $ronbun->user_id = Auth::user()->id;
+        $ronbun->save();
+        
+        // 画像データは別で上書き保存する
+        if (isset($request->thumbnail)) {
+            $file = $request->thumbnail;
+            $fileName = time() . '.' . $file->getClientOriginalExtension();
+            $target_path = public_path('/uploads/');
+            $file->move($target_path, $fileName);
+            $ronbun->fill(['thumbnail' => $fileName])->save();
+        }
+
+        return redirect('/mypage')->with('flash_message', __('Registered!'));
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/RonbunController.php
+++ b/app/Http/Controllers/RonbunController.php
@@ -67,7 +67,7 @@ class RonbunController extends Controller
             return redirect('/mypage')->with('flash_message', __('Invalid operation was performed.'));
         }
 
-        $ronbun = new Ronbun();
+        $ronbun = Ronbun::find($id);
         $ronbun->fill($request->all());
         $ronbun->user_id = Auth::user()->id;
         $ronbun->save();
@@ -81,7 +81,7 @@ class RonbunController extends Controller
             $ronbun->fill(['thumbnail' => $fileName])->save();
         }
 
-        return redirect('/mypage')->with('flash_message', __('Registered!'));
+        return redirect('/mypage')->with('flash_message', __('Updated!'));
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/UserController.php
+++ b/app/Http/Controllers/UserController.php
@@ -32,16 +32,16 @@ class UserController extends Controller
 
     public function edit()
     {
-        $jobs = Job::select('name')->get()->all();
+        $jobs = Job::select('id', 'name')->get()->all();
         $job_names = [];
         foreach ($jobs as $job) {
-            $job_names[] = $job->name;
+            $job_names[$job->id] = $job->name;
         }
 
-        $roles = Role::select('name')->get()->all();
+        $roles = Role::select('id', 'name')->get()->all();
         $role_names = [];
         foreach ($roles as $role) {
-            $role_names[] = $role->name;
+            $role_names[$role->id] = $role->name;
         }
         return view('user.edit', compact('job_names', 'role_names'));
     }

--- a/resources/lang/ja.json
+++ b/resources/lang/ja.json
@@ -10,6 +10,7 @@
   "Reset Password": "パスワード再発行",
   "Send Password Reset Link": "パスワード再発行リンクを送信",
   "Register Ronbun": "論文を投稿する",
+  "Edit Ronbun": "論文を編集する",
   "Title": "タイトル",
   "Category": "カテゴリー",
   "Author": "著者",

--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -40,7 +40,7 @@
                         </a>
                         <span class="content__category"></span>
                         <div class="content__button">
-                            <a href=""><i class="fas fa-pencil-alt content__button--edit"></i></a>
+                            <a href="{{ route('ronbun.edit', $ronbun->id) }}"><i class="fas fa-pencil-alt content__button--edit"></i></a>
                             <form method="post" action="{{ route('ronbun.delete', $ronbun->id) }}">
                                 @csrf
                                 <button type="submit" onclick="return confirm('本当に削除してもよろしいですか？');"><i class="fas fa-trash-alt content__button--trash"></i></button>

--- a/resources/views/ronbun/edit.blade.php
+++ b/resources/views/ronbun/edit.blade.php
@@ -1,0 +1,105 @@
+@extends('layouts.app')
+
+@section('content')
+  <div class="site-width">
+    <h1 class="title">{{__('Edit Ronbun')}}</h1>
+
+    {{ Form::open(['route' => 'ronbun.update', 'class' => 'postForm mainContainer', 'enctype' => 'multipart/form-data']) }}
+      <div class="postForm__container">
+        <div class="postForm__label">
+          {{ Form::label('title', __('Title'))}}
+          <span class="postForm__label--must">{{ __('Required') }}</span>
+        </div>
+        {{ Form::input('text', 'title', $ronbun->title, ['class' => 'postForm__input']) }}
+        @error('title')
+          <div class="area-msg">
+            {{ $message }}
+          </div>
+        @enderror
+      </div>
+
+      <div class="postForm__container">
+        <div class="postForm__label">
+          {{ Form::label('category_id', __('Category')) }}
+          <span class="postForm__label--must">{{ __('Required') }}</span>
+        </div>
+        {{ Form::select('category_id', null, ['class' => 'postForm__select', 'placeholder' => '選択してください']) }}
+        @error('category_id')
+          <div class="area-msg">
+            {{ $message }}
+          </div>
+        @enderror
+      </div>
+
+      <div class="postForm__container">
+        <div class="postForm__label">
+          {{ Form::label('author', __('Author')) }}
+          <span class="postForm__label--must">{{ __('Required') }}</span>
+        </div>
+        {{ Form::input('text', 'author',$ronbun->author, ['class' => 'postForm__input']) }}
+        @error('author')
+          <div class="area-msg">
+            {{ $message }}
+          </div>
+        @enderror
+      </div>
+
+      <div class="postForm__container">
+        <div class="postForm__label">
+          {{ Form::label('year', __('Year')) }}
+        </div>
+        {{ Form::input('number', 'year', $ronbun->year, ['class' => 'postForm__input--number']) }}
+        @error('year')
+          <div class="area-msg">
+            {{ $message }}
+          </div>
+        @enderror
+      </div>
+
+      <div class="postForm__container">
+        <div class="postForm__label">
+          {{ Form::label('abstract', __('Abstract')) }}
+          <span class="postForm__label--must">{{ __('Required') }}</span>
+        </div>
+        <ckeditor-component content="{{ $ronbun->abstract }}"></ckeditor-component>
+        @error('abstract')
+          <div class="area-msg">
+            {{ $message }}
+          </div>
+        @enderror
+      </div>
+
+      <div class="postForm__container">
+        <div class="postForm__label">
+          {{ Form::label('url', __('Original URL')) }}
+        </div>
+        {{ Form::input('text', 'url', $ronbun->url, ['class' => 'postForm__input']) }}
+        @error('url')
+          <div class="area-msg">
+            {{ $message }}
+          </div>
+        @enderror
+      </div>
+
+      <div class="postForm__container">
+        <div class="postForm__label">
+          {{ Form::label('thumbnail', __('Thumbnail')) }}
+        </div>
+        <div class="areaDrop">
+          {{ Form::hidden('MAX_IMAGE_SIZE', '3145728')}}
+          <imagepreview-component name="thumbnail" pic_path="/uploads/{{ $ronbun->thumbnail }}" pic="{{ $ronbun->thumbnail }}"></imagepreview-component>
+        </div>
+        @error('thumbnail')
+          <div class="area-msg">
+            {{ $message }}
+          </div>
+        @enderror
+      </div>
+
+      <div class="btnContainer">
+        {{ Form::button( __('Update'), ['type' => 'submit', 'class' => 'btn btn--right']) }}
+      </div>
+    {{ Form::close() }}
+    @include('sidebar_mypage')
+  </div>
+@endsection

--- a/resources/views/ronbun/edit.blade.php
+++ b/resources/views/ronbun/edit.blade.php
@@ -4,7 +4,8 @@
   <div class="site-width">
     <h1 class="title">{{__('Edit Ronbun')}}</h1>
 
-    {{ Form::open(['route' => 'ronbun.update', 'class' => 'postForm mainContainer', 'enctype' => 'multipart/form-data']) }}
+    <form action="{{ route('ronbun.update', $ronbun->id) }}" method="post" enctype="multipart/form-data" class="postForm mainContainer">
+      @csrf
       <div class="postForm__container">
         <div class="postForm__label">
           {{ Form::label('title', __('Title'))}}
@@ -23,7 +24,7 @@
           {{ Form::label('category_id', __('Category')) }}
           <span class="postForm__label--must">{{ __('Required') }}</span>
         </div>
-        {{ Form::select('category_id', null, ['class' => 'postForm__select', 'placeholder' => '選択してください']) }}
+        {{ Form::select('category_id', $category_names, $ronbun->category_id, ['class' => 'postForm__select', 'placeholder' => '選択してください']) }}
         @error('category_id')
           <div class="area-msg">
             {{ $message }}
@@ -99,7 +100,7 @@
       <div class="btnContainer">
         {{ Form::button( __('Update'), ['type' => 'submit', 'class' => 'btn btn--right']) }}
       </div>
-    {{ Form::close() }}
+    </form>
     @include('sidebar_mypage')
   </div>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -28,3 +28,4 @@ Route::get('/user/edit', 'UserController@edit')->name('user.edit');
 Route::post('/user/edit', 'UserController@update')->name('user.update');
 Route::post('/ronbun/{id}/delete', 'RonbunController@destroy')->name('ronbun.delete');
 Route::get('/ronbun/{id}/edit', 'RonbunController@edit')->name('ronbun.edit');
+Route::post('/ronbun/{id}/edit', 'RonbunController@update')->name('ronbun.update');

--- a/routes/web.php
+++ b/routes/web.php
@@ -27,3 +27,4 @@ Route::post('/withdraw', 'UserController@delete')->name('user.delete');
 Route::get('/user/edit', 'UserController@edit')->name('user.edit');
 Route::post('/user/edit', 'UserController@update')->name('user.update');
 Route::post('/ronbun/{id}/delete', 'RonbunController@destroy')->name('ronbun.delete');
+Route::get('/ronbun/{id}/edit', 'RonbunController@edit')->name('ronbun.edit');


### PR DESCRIPTION
# やったこと
- 論文編集用のルーティングの追加
- 論文編集時のメッセージの日本語化対応
- 論文編集時の画面を作成
- 論文編集画面表示、更新処理のメソッドを追加
- セレクトボックスのvalueがDBのIDと揃っていなかったので変更