### PR TITLE
論文詳細ページの作成

### DIFF
--- a/app/Http/Controllers/RonbunController.php
+++ b/app/Http/Controllers/RonbunController.php
@@ -36,7 +36,15 @@ class RonbunController extends Controller
 
         $ronbun = Ronbun::find($id);
 
-        return view('ronbun.show', compact('ronbun'));
+        // TODO: お気に入りテーブルとjoinをしてお気に入り件数が高いもの5件を表示するようにする
+        $pickup_ronbuns = DB::table('ronbuns')
+                                ->limit(5)
+                                ->orderBy('updated_at', 'desc')
+                                ->get();
+
+        $categories = Category::all();
+
+        return view('ronbun.show', compact('ronbun', 'pickup_ronbuns', 'categories'));
     }
 
     public function new()

--- a/app/Http/Controllers/RonbunController.php
+++ b/app/Http/Controllers/RonbunController.php
@@ -29,6 +29,16 @@ class RonbunController extends Controller
         return view('ronbun.index', compact('ronbuns', 'pickup_ronbuns', 'categories'));
     }
 
+    public function show($id) {
+        if (!ctype_digit($id)) {
+            return redirect('/')->with('flash_message', __('Invalid operation was performed.'));
+        }
+
+        $ronbun = Ronbun::find($id);
+
+        return view('ronbun.show', compact('ronbun'));
+    }
+
     public function new()
     {
         $categories = Category::select('name')->get()->all();

--- a/public/css/app.css
+++ b/public/css/app.css
@@ -192,6 +192,68 @@ a:hover {
   box-shadow: 0 0 10px 0 #ddd;
 }
 
+.ronbunBlock {
+  display: flex;
+  margin: 40px 0;
+}
+
+.ronbunBlock__thumbnail {
+  width: 40%;
+  margin-right: 15px;
+}
+
+.ronbunBlock__thumbnail img {
+  width: 100%;
+}
+
+.ronbunBlock__info {
+  width: 60%;
+  border-collapse: collapse;
+}
+
+.ronbunBlock__info tr {
+  border-bottom: solid 4px #f6f5f5;
+}
+
+.ronbunBlock__info tr:last-child {
+  border-bottom: none;
+}
+
+.ronbunBlock__info th {
+  color: #12157b;
+  position: relative;
+  text-align: left;
+  width: 30%;
+  height: 50px;
+  line-height: 50px;
+  background-color: #eee;
+  text-align: center;
+  padding: 10px 0;
+}
+
+.ronbunBlock__info th:after {
+  display: block;
+  content: "";
+  width: 0px;
+  height: 0px;
+  position: absolute;
+  top: calc(50% - 10px);
+  right: -10px;
+  border-left: 10px solid #eee;
+  border-top: 10px solid transparent;
+  border-bottom: 10px solid transparent;
+}
+
+.ronbunBlock__info td {
+  text-align: left;
+  width: 70%;
+  height: 50px;
+  line-height: 50px;
+  text-align: center;
+  background-color: #fff;
+  padding: 10px 0;
+}
+
 .form {
   width: 400px;
   margin: 80px auto;
@@ -405,10 +467,6 @@ a:hover {
   width: 100%;
 }
 
-.category__item {
-  margin-top: 10px;
-}
-
 .category__item a {
   display: block;
   padding: 10px;
@@ -416,6 +474,17 @@ a:hover {
 
 .category__item a:hover {
   background: #efefef;
+}
+
+.abstract {
+  margin-bottom: 20px;
+}
+
+.abstract__title {
+  display: inline-block;
+  font-size: 30px;
+  box-shadow: 0 -9px 0 0 #9698e2 inset;
+  margin-bottom: 15px;
 }
 
 .sidebarMypage {

--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -202,6 +202,63 @@ a:hover {
 }
 
 // ========================================
+// 論文詳細
+// ========================================
+.ronbunBlock {
+  display: flex;
+  margin: $space_3l 0;
+  &__thumbnail {
+    width: 40%;
+    margin-right: $space_l;
+    img {
+      width: 100%;
+    }
+  }
+  &__info {
+    width: 60%;
+    border-collapse: collapse;
+    tr {
+      border-bottom: solid 4px #f6f5f5;
+    }
+    tr:last-child {
+      border-bottom: none;
+    }
+    th {
+      color: $color_corp;
+      position: relative;
+      text-align: left;
+      width: 30%;
+      height: 50px;
+      line-height: 50px;
+      background-color: #eee;
+      text-align: center;
+      padding: 10px 0;
+    }
+    th:after {
+      display: block;
+      content: "";
+      width: 0px;
+      height: 0px;
+      position: absolute;
+      top:calc(50% - 10px);
+      right:-10px;
+      border-left: 10px solid #eee;
+      border-top: 10px solid transparent;
+      border-bottom: 10px solid transparent;
+    }
+    td {
+      text-align: left;
+      width: 70%;
+      height: 50px;
+      line-height: 50px;
+      text-align: center;
+      background-color: #fff;
+      padding: 10px 0;
+    }
+  }
+}
+
+// ========================================
 // フォーム
 // ========================================
 .form {
@@ -402,7 +459,6 @@ a:hover {
     width: 100%;
   }
   &__item {
-    margin-top: $space_m;
     a {
       display: block;
       padding: $space_m;
@@ -410,6 +466,16 @@ a:hover {
     a:hover {
       background: #efefef; 
     }
+  }
+}
+
+.abstract {
+  margin-bottom: $space_xl;
+  &__title {
+    display: inline-block;
+    font-size: $font-size_xxl;
+    box-shadow: 0 -9px 0 0 #9698e2 inset;
+    margin-bottom: $space_l;
   }
 }
 

--- a/resources/views/layouts/app.blade.php
+++ b/resources/views/layouts/app.blade.php
@@ -18,8 +18,8 @@
     <script src="https://kit.fontawesome.com/931c61dabd.js" crossorigin="anonymous"></script>
 
     <!-- Styles -->
-    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
     <link href="{{ asset('css/reset.css') }}" rel="stylesheet">
+    <link href="{{ asset('css/app.css') }}" rel="stylesheet">
 </head>
 <body>
     <div id="app">

--- a/resources/views/mypage.blade.php
+++ b/resources/views/mypage.blade.php
@@ -30,7 +30,7 @@
                 <div class="contents__container">
                     @foreach ($ronbuns as $ronbun)
                     <div class="content">
-                        <a href="" class="content__link">
+                        <a href="{{ route('ronbun.show', $ronbun->id) }}" class="content__link">
                             @if (isset($ronbun->thumbnail))
                             <img src="/uploads/{{ $ronbun->thumbnail }}" class="content__image">
                             @else

--- a/resources/views/ronbun/index.blade.php
+++ b/resources/views/ronbun/index.blade.php
@@ -12,7 +12,7 @@
         <div class="contents__container">
           @foreach ($ronbuns as $ronbun)
           <div class="content">
-            <a href="" class="content__link">
+            <a href="{{ route('ronbun.show', $ronbun->id) }}" class="content__link">
               @if (isset($ronbun->thumbnail))
                 <img src="/uploads/{{ $ronbun->thumbnail }}" class="content__image">
               @else

--- a/resources/views/ronbun/show.blade.php
+++ b/resources/views/ronbun/show.blade.php
@@ -1,0 +1,44 @@
+@extends('layouts.app')
+
+@section('content')
+  <div class="site-width">
+
+    <section class="mainContainer">
+      <h1 class="title">{{ $ronbun->title }}</h1>
+      <div class="ronbunBlock">
+        <div class="ronbunBlock__thumbnail">
+          @if (isset($ronbun->thumbnail))
+            <img src="/uploads/{{ $ronbun->thumbnail }}" alt="">
+          @else
+            <img src="{{ asset('/img/no_image.png') }}" alt="">
+          @endif
+        </div>
+        <table class="ronbunBlock__info">
+          <tr>
+            <th>カテゴリー</th>
+            <td><a href="">{{ $ronbun->category->name }}</a></td>
+          </tr>
+          <tr>
+            <th>著者</th>
+            <td>{{ $ronbun->author }}</td>
+          </tr>
+          <tr>
+            <th>出版年</th>
+            <td>{{ $ronbun->year }}年</td>
+          </tr>
+        </table>
+      </div>
+
+      <div class="abstract">
+        <h2 class="abstract__title">要約</h2>
+        {!! $ronbun->abstract !!}
+      </div>
+
+      @if(isset($ronbun->url))
+        <a href="{{ $ronbun->url }}" class="leadLink">オリジナル論文はこちら</a>
+      @endif
+    </section>
+
+    @include('ronbun.sidebar')
+  </div>
+@endsection

--- a/resources/views/ronbun/sidebar.blade.php
+++ b/resources/views/ronbun/sidebar.blade.php
@@ -2,7 +2,7 @@
   <section class="pickup">
     <h2 class="pickup__title">注目記事</h2>
     @foreach ($pickup_ronbuns as $pickup_ronbun)
-    <a href="">
+    <a href="{{ route('ronbun.show', $pickup_ronbun->id) }}">
       <div class="pickup__content">
         @if (isset($pickup_ronbun->thumbnail))
           <img src="/uploads/{{ $pickup_ronbun->thumbnail }}">

--- a/routes/web.php
+++ b/routes/web.php
@@ -16,6 +16,7 @@ use Illuminate\Support\Facades\Route;
 Auth::routes();
 
 Route::get('/', 'RonbunController@index')->name('ronbun.index');
+Route::get('/ronbun/{id}', 'RonbunController@show')->name('ronbun.show');
 Route::get('/mypage', 'UserController@mypage')->name('mypage');
 Route::get('/ronbun/new', 'RonbunController@new')->name('ronbun.new');
 Route::post('/ronbun/new', 'RonbunController@create');


### PR DESCRIPTION
# やったこと
- 論文詳細ページを作成した
- 論文詳細ページへ遷移するリンクを作成
- リセットCSSを先に読み込むようにする

## 画面
<img width="794" alt="スクリーンショット 2020-09-05 16 52 09" src="https://user-images.githubusercontent.com/42470564/92300731-2c912a80-ef98-11ea-8ae5-c7ab27e9e3be.png">
